### PR TITLE
Change  Replidog::Model#lock!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@
 *.a
 gemfiles/*.gemfile.lock
 mkmf.log
+
+# RubyMine Setting file.
+.idea/

--- a/lib/replidog/model.rb
+++ b/lib/replidog/model.rb
@@ -61,6 +61,13 @@ module Replidog
       ensure
         self.class.connection.current_connection_name = old_connection_name
       end
+
+      def with_lock
+        transaction do
+          lock!
+          yield
+        end
+      end
     end
 
     def replicated?

--- a/lib/replidog/model.rb
+++ b/lib/replidog/model.rb
@@ -54,19 +54,12 @@ module Replidog
     end
 
     module InstanceMethodsWithReplidogSupport
-      def lock!
+      def lock!(lock = true)
         old_connection_name = self.class.connection.current_connection_name
         self.class.connection.current_connection_name ||= :master
         super
       ensure
         self.class.connection.current_connection_name = old_connection_name
-      end
-
-      def with_lock
-        transaction do
-          lock!
-          yield
-        end
       end
     end
 

--- a/spec/replidog/model_spec.rb
+++ b/spec/replidog/model_spec.rb
@@ -311,7 +311,7 @@ describe Replidog::Model do
         Recipe.using(:master).create(title: "test")
         Recipe.using(:master) do
           Recipe.first.with_lock do
-            Recipe.first.update!(title: "test_update")
+            Recipe.first.update_attributes!(title: "test_update")
           end
           expect(Recipe.first).to eq Recipe.first
         end

--- a/spec/replidog/model_spec.rb
+++ b/spec/replidog/model_spec.rb
@@ -309,19 +309,19 @@ describe Replidog::Model do
     context "with using master name" do
       it "executes SQL query on master connection" do
         Recipe.using(:master).create(title: "test")
-        Recipe.using(:master) do
-          Recipe.first.with_lock do
-            Recipe.first.update_attributes!(title: "test_update")
-          end
-          expect(Recipe.first).to eq Recipe.first
+        Recipe.using(:master).first.with_lock do
+          Recipe.first.update_attributes!(title: "test_update")
         end
+        expect(Recipe.first).to eq Recipe.first
       end
     end
 
     context "with using slave name" do
       it "executes SQL query on slave connection" do
         Recipe.using(:slave1).create(title: "test")
-        expect{ Recipe.first.with_lock }.to raise_error(NoMethodError)
+        Recipe.using(:slave2).create(title: "test")
+        Recipe.using(:slave3).create(title: "test")
+        expect{ Recipe.first.with_lock }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
   end

--- a/spec/replidog/model_spec.rb
+++ b/spec/replidog/model_spec.rb
@@ -304,4 +304,25 @@ describe Replidog::Model do
       end
     end
   end
+
+  describe "#with_lock" do
+    context "with using master name" do
+      it "executes SQL query on master connection" do
+        Recipe.using(:master).create(title: "test")
+        Recipe.using(:master) do
+          Recipe.first.with_lock do
+            Recipe.first.update!(title: "test_update")
+          end
+          expect(Recipe.first).to eq Recipe.first
+        end
+      end
+    end
+
+    context "with using slave name" do
+      it "executes SQL query on slave connection" do
+        Recipe.using(:slave1).create(title: "test")
+        expect{ Recipe.first.with_lock }.to raise_error(NoMethodError)
+      end
+    end
+  end
 end


### PR DESCRIPTION
I using ActiveRecord in with_lock.
https://github.com/rails/rails/blob/master/activerecord/lib/active_record/locking/pessimistic.rb#L81-L86
But, Used replidog with with_lock to Occurred `ArgumentError`.
```ruby
ArgumentError: wrong number of arguments (given 1, expected 0)
```

I check replidog in source.
Nothing `with_lock` method.
So make `with_lock` method.

Please review this pull request.